### PR TITLE
Enhance hybrid recommender with popularity, cross‑exploration, diversity and improved weighting

### DIFF
--- a/backend/tests/recommendation.test.js
+++ b/backend/tests/recommendation.test.js
@@ -40,16 +40,15 @@ describe('Hybrid Recommendation Engine', () => {
       const weights = recommendationEngine.calculateWeights(userProfile);
       
       expect(weights.content).toBeGreaterThan(weights.collaborative);
-      expect(weights.content).toBe(0.8);
-      expect(weights.collaborative).toBe(0.2);
+      expect(weights.content).toBeGreaterThan(weights.popularity);
     });
 
     it('should return balanced weights for intermediate users', () => {
       const userProfile = { ratingCount: 25 };
       const weights = recommendationEngine.calculateWeights(userProfile);
       
-      expect(weights.content).toBe(0.6);
-      expect(weights.collaborative).toBe(0.4);
+      expect(weights.collaborative).toBeGreaterThan(weights.content);
+      expect(weights.cross).toBeGreaterThan(0);
     });
 
     it('should return collaborative-heavy weights for experienced users', () => {
@@ -82,17 +81,27 @@ describe('Hybrid Recommendation Engine', () => {
       const collaborativeScores = [
         { movieId: 1, score: 0.6, movie: { id: 1, title: 'Movie 1' } }
       ];
+
+      const popularityScores = [
+        { movieId: 1, score: 0.4, movie: { id: 1, title: 'Movie 1' } }
+      ];
+
+      const crossScores = [
+        { movieId: 1, score: 0.5, movie: { id: 1, title: 'Movie 1' } }
+      ];
       
-      const weights = { content: 0.7, collaborative: 0.3 };
+      const weights = { content: 0.6, collaborative: 0.3, popularity: 0.05, cross: 0.05 };
       
       const hybridScores = recommendationEngine.combineScores(
         contentScores,
         collaborativeScores,
+        popularityScores,
+        crossScores,
         weights
       );
       
       expect(hybridScores).toHaveLength(1);
-      expect(hybridScores[0].score).toBeCloseTo(0.74); // 0.8 * 0.7 + 0.6 * 0.3
+      expect(hybridScores[0].score).toBeCloseTo(0.695); // 0.8*0.6 + 0.6*0.3 + 0.4*0.05 + 0.5*0.05
       expect(hybridScores[0].source).toBe('hybrid');
     });
   });


### PR DESCRIPTION
### Motivation
- Improve hybrid recommendation quality by adding popularity and cross-exploration signals and by making weighting adaptive to richer user signals. 
- Introduce diversity and explanation capabilities so recommendations are more discoverable and interpretable. 
- Strengthen content-based signals by deriving preferences from rating metadata (genres/directors/actors/runtime/year) to feed the ML/online learning pipeline.

### Description
- Extended `backend/services/recommendationEngine.js` to include popularity and cross-exploration scoring pipelines and to accept new options `diversityFactor` and `includeExplanations` in `generateRecommendations`. 
- Reworked weighting logic in `calculateWeights` and added `normalizeWeights` so weights adapt to `ratingVariance`, `avgRating`, `engagement` and user longevity, and added a `cross` weight. 
- Enhanced content preference extraction in `calculateUserPreferences` (normalizing genre/director/actor signals, runtime/year preferences) and improved `calculateContentSimilarity` with `calculatePreferenceScore`, `calculateRuntimeScore` and `calculateYearScore`. 
- Combined scores now include content, collaborative, popularity and cross signals in `combineScores`, plus optional explanation generation via `generateExplanations` and post-processing diversity via `applyDiversityFilter`. 
- Added helper functions `crossRecommendation`, `getPopularityBasedScores`, `calculatePopularityScore`, `normalizeRatingSignal`, and several runtime/year preference helpers to support the above. 
- Updated unit tests in `backend/tests/recommendation.test.js` to reflect the new weight structure and composite score calculation.

### Testing
- Updated unit tests: modified `backend/tests/recommendation.test.js` to validate the new composite scoring and weight outputs (tests were changed but not executed here). 
- No automated test suite was run as part of this change in this rollout (no CI/test run requested). 
- Manual/CI test recommendation: run `npm test` / `jest --testPathPattern=tests/recommendation` and exercise endpoints that call `generateRecommendations` with representative user profiles and movie fixtures to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a6a5644883268fbbdf61fa140677)