### PR TITLE
Add no-op chat widget script fallbacks

### DIFF
--- a/public/chmln.js
+++ b/public/chmln.js
@@ -1,0 +1,14 @@
+(function () {
+  if (window.chmln) {
+    return;
+  }
+
+  const queue = [];
+  const chmln = function () {
+    queue.push(arguments);
+  };
+
+  chmln.q = queue;
+  chmln.enabled = false;
+  window.chmln = chmln;
+})();

--- a/public/messo.min.js
+++ b/public/messo.min.js
@@ -1,0 +1,14 @@
+(function () {
+  if (window.chmln) {
+    return;
+  }
+
+  const queue = [];
+  const chmln = function () {
+    queue.push(arguments);
+  };
+
+  chmln.q = queue;
+  chmln.enabled = false;
+  window.chmln = chmln;
+})();


### PR DESCRIPTION
### Motivation
- Prevent runtime errors (e.g. `Uncaught SyntaxError: Unexpected token '<'` and undefined `chmln` access) when the chat widget scripts are requested but the real SDK is missing or returns HTML.

### Description
- Add two static no-op fallback scripts, `public/messo.min.js` and `public/chmln.js`, which install a stub `window.chmln` function with a queued API (`chmln.q`) and `chmln.enabled = false` to safely absorb calls from the app.

### Testing
- No automated tests were run for this change because it is a static asset addition only and does not affect runtime logic beyond providing safe fallbacks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698429a04a348326aa39bcf4ffd00b5e)