### PR TITLE
Apply filters to AI recommendations list

### DIFF
--- a/src/features/recommendation/hooks/useMovieData.ts
+++ b/src/features/recommendation/hooks/useMovieData.ts
@@ -584,13 +584,61 @@ export const useMovieData = (settings?: AppSettings) => {
 
   // Filter recommendations when filters change with error handling
   useEffect(() => {
-    if (!Array.isArray(recommendations) || recommendations.length === 0) return;
+    if (!Array.isArray(recommendations) || recommendations.length === 0) {
+      safeSetState(setFilteredRecommendationsLocal, [], []);
+      return;
+    }
     
     try {
+      const resolveMediaType = (item: Movie | TVShow) => {
+        if (item.media_type) {
+          return item.media_type;
+        }
+        return 'title' in item ? 'movie' : 'tv';
+      };
+
+      const resolveYear = (item: Movie | TVShow) => {
+        const date = 'release_date' in item ? item.release_date : item.first_air_date;
+        if (!date) {
+          return 0;
+        }
+        const year = Number(date.slice(0, 4));
+        return Number.isNaN(year) ? 0 : year;
+      };
+
       const filterRecommendations = () => {
-        // Artık filtreler yeni öneriler oluştururken kullanılacak, mevcut önerileri filtrelemeyecek
-        // Sadece sıralama uygulanacak
-        const filtered = [...recommendations];
+        let filtered = [...recommendations];
+
+        if (recommendationFilters.mediaType !== 'all') {
+          filtered = filtered.filter(rec => resolveMediaType(rec.movie) === recommendationFilters.mediaType);
+        }
+
+        if (Array.isArray(recommendationFilters.genres) && recommendationFilters.genres.length > 0) {
+          filtered = filtered.filter(rec => {
+            if (!rec.movie?.genre_ids || !Array.isArray(rec.movie.genre_ids)) return false;
+            return recommendationFilters.genres.some(genreId => rec.movie.genre_ids.includes(genreId));
+          });
+        }
+
+        filtered = filtered.filter(rec => {
+          const rating = typeof rec.movie?.vote_average === 'number' ? rec.movie.vote_average : 0;
+          return rating >= recommendationFilters.minRating && rating <= recommendationFilters.maxRating;
+        });
+
+        filtered = filtered.filter(rec => {
+          const year = resolveYear(rec.movie);
+          if (!year) return false;
+          return year >= recommendationFilters.minYear && year <= recommendationFilters.maxYear;
+        });
+
+        filtered = filtered.filter(rec => (rec.matchScore || 0) >= recommendationFilters.minMatchScore);
+
+        if (Array.isArray(recommendationFilters.languages) && recommendationFilters.languages.length > 0) {
+          filtered = filtered.filter(rec => {
+            const language = rec.movie?.original_language;
+            return language ? recommendationFilters.languages?.includes(language) : false;
+          });
+        }
 
         // Sort with error handling
         filtered.sort((a, b) => {
@@ -601,13 +649,7 @@ export const useMovieData = (settings?: AppSettings) => {
               case 'rating':
                 return (b.movie?.vote_average || 0) - (a.movie?.vote_average || 0);
               case 'year':
-                const yearA = 'release_date' in (a.movie || {}) ? 
-                  new Date((a.movie as any).release_date || '').getFullYear() : 
-                  new Date((a.movie as any).first_air_date || '').getFullYear();
-                const yearB = 'release_date' in (b.movie || {}) ? 
-                  new Date((b.movie as any).release_date || '').getFullYear() : 
-                  new Date((b.movie as any).first_air_date || '').getFullYear();
-                return (yearB || 0) - (yearA || 0);
+                return resolveYear(b.movie) - resolveYear(a.movie);
               case 'title':
                 const titleA = 'title' in (a.movie || {}) ? (a.movie as any).title : (a.movie as any).name;
                 const titleB = 'title' in (b.movie || {}) ? (b.movie as any).title : (b.movie as any).name;
@@ -632,7 +674,12 @@ export const useMovieData = (settings?: AppSettings) => {
         handleError(new Error(String(error)), 'Öneri filtreleme');
       }
     }
-  }, [recommendations, recommendationFilters.sortBy, handleError, safeSetState]);
+  }, [
+    recommendations,
+    recommendationFilters,
+    handleError,
+    safeSetState
+  ]);
 
   // Filter curated content when filters change with error handling
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Make the AI recommendations view respect the user's active recommendation filters so displayed suggestions match media type, genres, rating, year, match score and language choices.

### Description
- Updated the recommendations filtering effect in `src/features/recommendation/hooks/useMovieData.ts` to apply media type, genre IDs, TMDb rating range, year range, `minMatchScore` and language filters before setting `filteredRecommendations`.
- Added helper resolvers for media type and year (`resolveMediaType`, `resolveYear`) and improved null checks to avoid runtime errors while preserving sorting by `recommendationFilters.sortBy`.
- Ensure `filteredRecommendations` is cleared when `recommendations` is empty and expanded the effect dependency to watch the entire `recommendationFilters` object.

### Testing
- No automated tests were executed for this change.
- Existing test suites in the project (for example neural recommendation tests) were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842b81d3248326aef1683a0e850f69)