### PR TITLE
Ensure recommendation genres match TMDb and de-duplicate movie/TV genres

### DIFF
--- a/src/features/recommendation/components/RecommendationFilters.tsx
+++ b/src/features/recommendation/components/RecommendationFilters.tsx
@@ -139,17 +139,22 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
     (filters.minMatchScore !== 0 ? 1 : 0) +
     ((filters.languages || []).length > 0 ? 1 : 0), [filters]);
 
+  const popularGenreIds = [28, 35, 18, 12, 878, 27, 10749, 53, 16, 80, 14, 10765];
+  const genreMap = useMemo(() => new Map(genres.map(genre => [genre.id, genre])), [genres]);
+  const popularGenres = useMemo(() => popularGenreIds
+    .map(id => genreMap.get(id))
+    .filter((genre): genre is Genre => Boolean(genre)), [genreMap]);
+
   // Popüler türleri önce göster
   const sortedGenres = useMemo(() => [...genres].sort((a, b) => {
-    const popularGenres = [28, 35, 18, 878, 27, 10749, 53, 16, 80, 12, 14, 10765]; // Popüler tür ID'leri
-    const aIndex = popularGenres.indexOf(a.id);
-    const bIndex = popularGenres.indexOf(b.id);
+    const aIndex = popularGenreIds.indexOf(a.id);
+    const bIndex = popularGenreIds.indexOf(b.id);
     
     if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
     if (aIndex !== -1) return -1;
     if (bIndex !== -1) return 1;
     return a.name.localeCompare(b.name, 'tr');
-  }), [genres]);
+  }), [genres, popularGenreIds]);
 
   const [showOtherLanguages, setShowOtherLanguages] = React.useState(false);
 
@@ -429,16 +434,7 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
             <div className="mb-3">
               <p className="text-xs text-theme-tertiary mb-2">Popüler Türler:</p>
               <div className="flex flex-wrap gap-2">
-                {[
-                  { id: 28, name: 'Aksiyon' },
-                  { id: 35, name: 'Komedi' },
-                  { id: 18, name: 'Dram' },
-                  { id: 878, name: 'Bilim Kurgu' },
-                  { id: 10765, name: 'Bilim Kurgu & Fantazi' },
-                  { id: 27, name: 'Korku' },
-                  { id: 10749, name: 'Romantik' },
-                  { id: 53, name: 'Gerilim' }
-                ].map((genre) => (
+                {popularGenres.map((genre) => (
                   <button
                     key={genre.id}
                     onClick={() => toggleGenre(genre.id)}
@@ -459,7 +455,7 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
               <p className="text-xs text-theme-tertiary mb-2">Diğer Türler:</p>
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-48 overflow-y-auto">
-              {sortedGenres.filter(genre => ![28, 35, 18, 878, 10765, 27, 10749, 53].includes(genre.id)).map((genre) => (
+              {sortedGenres.filter(genre => !popularGenreIds.includes(genre.id)).map((genre) => (
                 <button
                   key={genre.id}
                   onClick={() => toggleGenre(genre.id)}

--- a/src/features/recommendation/hooks/useMovieData.ts
+++ b/src/features/recommendation/hooks/useMovieData.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import type { Movie, TVShow, Genre, UserRating, UserProfile, Recommendation } from '../../content/types';
 import { tmdbService } from '../../content/services/tmdb';
 
@@ -584,13 +584,88 @@ export const useMovieData = (settings?: AppSettings) => {
 
   // Filter recommendations when filters change with error handling
   useEffect(() => {
-    if (!Array.isArray(recommendations) || recommendations.length === 0) return;
+    if (!Array.isArray(recommendations) || recommendations.length === 0) {
+      safeSetState(setFilteredRecommendationsLocal, [], []);
+      return;
+    }
     
     try {
+      const resolveMediaType = (item: Movie | TVShow) => {
+        if (item.media_type) {
+          return item.media_type;
+        }
+        return 'title' in item ? 'movie' : 'tv';
+      };
+
+      const resolveYear = (item: Movie | TVShow) => {
+        const date = 'release_date' in item ? item.release_date : item.first_air_date;
+        if (!date) {
+          return 0;
+        }
+        const year = Number(date.slice(0, 4));
+        return Number.isNaN(year) ? 0 : year;
+      };
+
       const filterRecommendations = () => {
-        // Artık filtreler yeni öneriler oluştururken kullanılacak, mevcut önerileri filtrelemeyecek
-        // Sadece sıralama uygulanacak
-        const filtered = [...recommendations];
+        let filtered = [...recommendations];
+
+        // Çocuk içeriklerini her zaman filtrele (TMDb filtreleri ile uyumlu)
+        filtered = filtered.filter(rec => {
+          if (!rec?.movie?.genre_ids) return true;
+          const isKidsGenre = rec.movie.genre_ids.includes(16) || rec.movie.genre_ids.includes(10751);
+          return !isKidsGenre;
+        });
+
+        if (recommendationFilters.mediaType !== 'all') {
+          filtered = filtered.filter(rec => resolveMediaType(rec.movie) === recommendationFilters.mediaType);
+        }
+
+        if (Array.isArray(recommendationFilters.genres) && recommendationFilters.genres.length > 0) {
+          filtered = filtered.filter(rec => {
+            if (!rec.movie?.genre_ids || !Array.isArray(rec.movie.genre_ids)) return false;
+            return recommendationFilters.genres.some(genreId => rec.movie.genre_ids.includes(genreId));
+          });
+        }
+
+        filtered = filtered.filter(rec => {
+          if (!rec?.movie || typeof rec.movie.vote_average !== 'number' || typeof rec.movie.vote_count !== 'number') {
+            return false;
+          }
+          const minRating = Math.max(6.0, recommendationFilters.minRating);
+          return rec.movie.vote_average >= minRating && 
+            rec.movie.vote_average <= recommendationFilters.maxRating &&
+            rec.movie.vote_count >= 100;
+        });
+
+        filtered = filtered.filter(rec => {
+          const year = resolveYear(rec.movie);
+          if (!year) return true;
+          return year >= recommendationFilters.minYear && year <= recommendationFilters.maxYear;
+        });
+
+        filtered = filtered.filter(rec => (rec.matchScore || 0) >= recommendationFilters.minMatchScore);
+
+        if (Array.isArray(recommendationFilters.languages) && recommendationFilters.languages.length > 0) {
+          filtered = filtered.filter(rec => {
+            const language = rec.movie?.original_language;
+            return language ? recommendationFilters.languages?.includes(language) : false;
+          });
+        }
+
+        if (recommendationFilters.showAnimationContent === false) {
+          filtered = filtered.filter(rec => {
+            if (!rec?.movie?.genre_ids) return true;
+            return !rec.movie.genre_ids.includes(16);
+          });
+        }
+
+        if (recommendationFilters.showAnimeContent === false) {
+          filtered = filtered.filter(rec => {
+            if (!rec?.movie?.genre_ids) return true;
+            const isAnime = rec.movie.genre_ids.includes(16) && rec.movie.original_language === 'ja';
+            return !isAnime;
+          });
+        }
 
         // Sort with error handling
         filtered.sort((a, b) => {
@@ -601,13 +676,7 @@ export const useMovieData = (settings?: AppSettings) => {
               case 'rating':
                 return (b.movie?.vote_average || 0) - (a.movie?.vote_average || 0);
               case 'year':
-                const yearA = 'release_date' in (a.movie || {}) ? 
-                  new Date((a.movie as any).release_date || '').getFullYear() : 
-                  new Date((a.movie as any).first_air_date || '').getFullYear();
-                const yearB = 'release_date' in (b.movie || {}) ? 
-                  new Date((b.movie as any).release_date || '').getFullYear() : 
-                  new Date((b.movie as any).first_air_date || '').getFullYear();
-                return (yearB || 0) - (yearA || 0);
+                return resolveYear(b.movie) - resolveYear(a.movie);
               case 'title':
                 const titleA = 'title' in (a.movie || {}) ? (a.movie as any).title : (a.movie as any).name;
                 const titleB = 'title' in (b.movie || {}) ? (b.movie as any).title : (b.movie as any).name;
@@ -632,7 +701,12 @@ export const useMovieData = (settings?: AppSettings) => {
         handleError(new Error(String(error)), 'Öneri filtreleme');
       }
     }
-  }, [recommendations, recommendationFilters.sortBy, handleError, safeSetState]);
+  }, [
+    recommendations,
+    recommendationFilters,
+    handleError,
+    safeSetState
+  ]);
 
   // Filter curated content when filters change with error handling
   useEffect(() => {
@@ -1335,6 +1409,17 @@ export const useMovieData = (settings?: AppSettings) => {
     };
   }, []);
 
+  const mergedGenres = useMemo(() => {
+    const uniqueGenres = new Map<number, Genre>();
+    (Array.isArray(genres) ? genres : []).forEach(genre => uniqueGenres.set(genre.id, genre));
+    (Array.isArray(tvGenres) ? tvGenres : []).forEach(genre => {
+      if (!uniqueGenres.has(genre.id)) {
+        uniqueGenres.set(genre.id, genre);
+      }
+    });
+    return Array.from(uniqueGenres.values());
+  }, [genres, tvGenres]);
+
   return {
     user: null,
     profile,
@@ -1347,7 +1432,7 @@ export const useMovieData = (settings?: AppSettings) => {
     updateProfile: undefined,
     movies: Array.isArray(movies) ? movies : [],
     allMovies: Array.isArray(allMovies) ? allMovies : [],
-    genres: [...(Array.isArray(genres) ? genres : []), ...(Array.isArray(tvGenres) ? tvGenres : [])],
+    genres: mergedGenres,
     recommendations: Array.isArray(recommendations) ? recommendations : [],
     filteredRecommendations: Array.isArray(filteredRecommendations) ? filteredRecommendations : [],
     loading,


### PR DESCRIPTION
### Motivation
- Ensure the recommendation filter UI uses the exact TMDb genre names/IDs (so genres like Dram/Macera/Aksiyon match TMDb), removing hardcoded labels.
- Provide a single deduplicated genre list from both movie and TV genre endpoints and make filtering behavior match TMDb-based generator rules.

### Description
- Drive the popular and full genre lists from TMDb data by mapping `popularGenreIds` to the `genres` payload and removing hardcoded genre name strings in `RecommendationFilters.tsx`.
- De-duplicate combined movie/TV genres with a `mergedGenres` `useMemo` and expose that single list from `useMovieData` instead of concatenating arrays.
- Replace brittle filter/sort logic in `useMovieData` with small helpers `resolveMediaType` and `resolveYear`, always filter out kids genres (TMDb IDs `16` and `10751`), and apply mediaType, genres, languages, minMatchScore, year range, and vote/rating thresholds (`vote_count >= 100` and `minRating = Math.max(6.0, recommendationFilters.minRating)`) consistently.
- Honor `showAnimationContent` and `showAnimeContent` toggles, clear `filteredRecommendations` when the source `recommendations` array is empty, and broaden the `useEffect` dependency to watch the entire `recommendationFilters` object.

### Testing
- Ran the dev server with `npm run dev` which reported Vite as ready (local server available), though the environment raised an `xdg-open ENOENT` when trying to open the browser; the server remained responsive.
- Executed the Playwright navigation script which loaded the app and produced a screenshot artifact successfully at `artifacts/recommendations-filters.png`.
- No unit/integration test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842b81d3248326aef1683a0e850f69)