### PR TITLE
Align recommendation filters with TMDb score/vote-count settings

### DIFF
--- a/src/features/recommendation/hooks/useMovieData.ts
+++ b/src/features/recommendation/hooks/useMovieData.ts
@@ -515,7 +515,11 @@ export const useMovieData = (settings?: AppSettings) => {
               tvGenresData,
               validRatings,
               { ...recommendationFilters, showKidsContent: settings?.showKidsContent ?? false, showAnimationContent: settings?.showAnimationContent ?? true, showAnimeContent: settings?.showAnimeContent ?? true },
-              settings?.recommendationCount !== undefined ? { recommendationCount: settings.recommendationCount } : {},
+              settings ? {
+                recommendationCount: settings.recommendationCount,
+                minTmdbScore: settings.minTmdbScore,
+                minTmdbVoteCount: settings.minTmdbVoteCount
+              } : {},
               watchlistIds
             );
             safeSetState(setRecommendationsLocal, recs, []);
@@ -627,14 +631,15 @@ export const useMovieData = (settings?: AppSettings) => {
           });
         }
 
+        const minRating = Math.max(settings?.minTmdbScore ?? 0, recommendationFilters.minRating);
+        const minVoteCount = settings?.minTmdbVoteCount ?? 0;
         filtered = filtered.filter(rec => {
           if (!rec?.movie || typeof rec.movie.vote_average !== 'number' || typeof rec.movie.vote_count !== 'number') {
             return false;
           }
-          const minRating = Math.max(6.0, recommendationFilters.minRating);
           return rec.movie.vote_average >= minRating && 
             rec.movie.vote_average <= recommendationFilters.maxRating &&
-            rec.movie.vote_count >= 100;
+            rec.movie.vote_count >= minVoteCount;
         });
 
         filtered = filtered.filter(rec => {
@@ -705,7 +710,8 @@ export const useMovieData = (settings?: AppSettings) => {
     recommendations,
     recommendationFilters,
     handleError,
-    safeSetState
+    safeSetState,
+    settings
   ]);
 
   // Filter curated content when filters change with error handling
@@ -1036,7 +1042,11 @@ export const useMovieData = (settings?: AppSettings) => {
             tvGenres,
             newRatings,
             { ...recommendationFilters, showKidsContent: settings?.showKidsContent ?? false, showAnimationContent: settings?.showAnimationContent ?? true, showAnimeContent: settings?.showAnimeContent ?? true },
-            settings?.recommendationCount !== undefined ? { recommendationCount: settings.recommendationCount } : {},
+            settings ? {
+              recommendationCount: settings.recommendationCount,
+              minTmdbScore: settings.minTmdbScore,
+              minTmdbVoteCount: settings.minTmdbVoteCount
+            } : {},
             watchlistIds
           );
           safeSetState(setRecommendationsLocal, recs, []);
@@ -1203,7 +1213,11 @@ export const useMovieData = (settings?: AppSettings) => {
         tvGenres,
         Array.isArray(ratings) ? ratings : [],
         recommendationFilters, // Filtreleri geçir
-        settings?.recommendationCount !== undefined ? { recommendationCount: settings.recommendationCount } : {} // Ayarları geçir
+        settings ? {
+          recommendationCount: settings.recommendationCount,
+          minTmdbScore: settings.minTmdbScore,
+          minTmdbVoteCount: settings.minTmdbVoteCount
+        } : {} // Ayarları geçir
       );
       
       // Filtrelenmiş önerileri doğrudan set et
@@ -1222,7 +1236,7 @@ export const useMovieData = (settings?: AppSettings) => {
       setRecommendationsLoading(false);
       setRecommendationsLoadingProgress({ current: 0, total: 0, message: '' });
     }
-  }, [profile, genres, tvGenres, ratings, recommendationFilters, handleError, safeSetState, recommendationsLoading]);
+  }, [profile, genres, tvGenres, ratings, recommendationFilters, handleError, safeSetState, recommendationsLoading, settings]);
 
   // Refresh curated content with filters
   const refreshCuratedContent = useCallback(async () => {

--- a/src/features/recommendation/services/recommendationService.ts
+++ b/src/features/recommendation/services/recommendationService.ts
@@ -27,6 +27,8 @@ export class RecommendationService {
     },
     settings?: {
       recommendationCount?: number;
+      minTmdbScore?: number;
+      minTmdbVoteCount?: number;
     },
     watchlistIds?: number[]
   ): Promise<Recommendation[]> {
@@ -183,11 +185,13 @@ export class RecommendationService {
       });
 
       // Rating filter
+      const minRating = Math.max(filters.minRating, settings?.minTmdbScore ?? 0);
+      const minVoteCount = settings?.minTmdbVoteCount ?? 0;
       filteredRecommendations = filteredRecommendations.filter(rec => {
         if (!rec?.movie || typeof rec.movie.vote_average !== 'number' || typeof rec.movie.vote_count !== 'number') return false;
-        return rec.movie.vote_average >= Math.max(6.0, filters.minRating) && 
+        return rec.movie.vote_average >= minRating && 
                rec.movie.vote_average <= filters.maxRating &&
-               rec.movie.vote_count >= 100;
+               rec.movie.vote_count >= minVoteCount;
       });
 
       // Language filter


### PR DESCRIPTION
### Motivation
- Users reported items with high profile match scores being excluded from results; investigation showed hard-coded TMDb thresholds could remove valid content despite filters matching.
- Make recommendation filtering respect user-configured TMDb thresholds so AI lists and UI filtering behave consistently.

### Description
- Use `settings.minTmdbScore` and `settings.minTmdbVoteCount` instead of hard-coded `6.0` and `100` when applying rating/vote-count filters in `RecommendationService` and `useMovieData`.
- Add `minTmdbScore` and `minTmdbVoteCount` to the `generateRecommendations` `settings` parameter and thread those settings through calls from `useMovieData` (initial generation, refresh, and post-rating flows) when available.
- Update filtering logic in `src/features/recommendation/hooks/useMovieData.ts` to compute `minRating`/`minVoteCount` from `settings` and include `settings` in the `useEffect` dependency list where needed.
- Remove previously hard-coded thresholds so recommendation generation and on-page filtering are aligned with user/profile settings.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842f9791bc8326922d04046b98b33a)