### PR TITLE
Remove minimum TMDB vote count setting and vote-count filtering

### DIFF
--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -134,7 +134,6 @@ export const OnboardingFlow: React.FC<OnboardingFlowProps> = ({
               showAdultContent: false,
               minContentRating: 6.0,
               minTmdbScore: 6.0,
-              minTmdbVoteCount: 100,
               showKidsContent: false,
               showAnimationContent: true,
               showAnimeContent: true,

--- a/src/features/profile/components/SettingsModal.tsx
+++ b/src/features/profile/components/SettingsModal.tsx
@@ -32,7 +32,6 @@ export interface AppSettings {
   showAdultContent: boolean;
   minContentRating: number;
   minTmdbScore: number;
-  minTmdbVoteCount: number;
   showKidsContent: boolean;
   showAnimationContent: boolean;
   showAnimeContent: boolean;
@@ -90,7 +89,6 @@ const defaultSettings: AppSettings = {
   showAdultContent: false,
   minContentRating: 6.0,
   minTmdbScore: 6.0,
-  minTmdbVoteCount: 100,
   showKidsContent: false,
   showAnimationContent: true,
   showAnimeContent: true,
@@ -631,25 +629,6 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
                       </div>
                     </div>
 
-                    <div className="mt-6">
-                      <label className="block text-sm font-medium text-theme-primary mb-3">
-                        Minimum Oy Sayısı: {localSettings.minTmdbVoteCount}
-                      </label>
-                      <p className="text-xs text-theme-tertiary mb-3">TMDB'de minimum kaç kişi puanlamış olması gerekir</p>
-                      <input
-                        type="range"
-                        min="10"
-                        max="5000"
-                        step="50"
-                        value={localSettings.minTmdbVoteCount}
-                        onChange={(e) => updateSetting('minTmdbVoteCount', parseInt(e.target.value))}
-                        className="w-full h-2 bg-theme-tertiary rounded-lg appearance-none cursor-pointer slider"
-                      />
-                      <div className="flex justify-between text-xs text-theme-tertiary mt-2">
-                        <span>10</span>
-                        <span>5000</span>
-                      </div>
-                    </div>
                   </div>
 
                   {/* Content Categories */}

--- a/src/features/profile/hooks/useSettings.ts
+++ b/src/features/profile/hooks/useSettings.ts
@@ -12,7 +12,6 @@ const defaultSettings: AppSettings = {
   showAdultContent: false,
   minContentRating: 6.0,
   minTmdbScore: 6.0,
-  minTmdbVoteCount: 100,
   showKidsContent: false,
   showAnimationContent: true,
   showAnimeContent: true,

--- a/src/features/recommendation/hooks/useMovieData.ts
+++ b/src/features/recommendation/hooks/useMovieData.ts
@@ -299,14 +299,6 @@ export const useMovieData = (settings?: AppSettings) => {
         );
       }
 
-      // Apply TMDB vote count filter
-      if (settings?.minTmdbVoteCount && typeof settings.minTmdbVoteCount === 'number') {
-        unratedResults = unratedResults.filter(item => 
-          item && typeof item.vote_count === 'number' &&
-          item.vote_count >= settings.minTmdbVoteCount
-        );
-      }
-
       if (settings && !settings.showAdultContent) {
         unratedResults = unratedResults.filter(item => !('adult' in item && !!item.adult));
       }
@@ -355,14 +347,6 @@ export const useMovieData = (settings?: AppSettings) => {
           unratedResults = unratedResults.filter(item => 
             item && typeof item.vote_average === 'number' &&
             item.vote_average >= settings.minTmdbScore
-          );
-        }
-
-        // Apply TMDB vote count filter
-        if (settings?.minTmdbVoteCount && typeof settings.minTmdbVoteCount === 'number') {
-          unratedResults = unratedResults.filter(item => 
-            item && typeof item.vote_count === 'number' &&
-            item.vote_count >= settings.minTmdbVoteCount
           );
         }
 
@@ -517,8 +501,7 @@ export const useMovieData = (settings?: AppSettings) => {
               { ...recommendationFilters, showKidsContent: settings?.showKidsContent ?? false, showAnimationContent: settings?.showAnimationContent ?? true, showAnimeContent: settings?.showAnimeContent ?? true },
               settings ? {
                 recommendationCount: settings.recommendationCount,
-                minTmdbScore: settings.minTmdbScore,
-                minTmdbVoteCount: settings.minTmdbVoteCount
+                minTmdbScore: settings.minTmdbScore
               } : {},
               watchlistIds
             );
@@ -632,14 +615,12 @@ export const useMovieData = (settings?: AppSettings) => {
         }
 
         const minRating = Math.max(settings?.minTmdbScore ?? 0, recommendationFilters.minRating);
-        const minVoteCount = settings?.minTmdbVoteCount ?? 0;
         filtered = filtered.filter(rec => {
-          if (!rec?.movie || typeof rec.movie.vote_average !== 'number' || typeof rec.movie.vote_count !== 'number') {
+          if (!rec?.movie || typeof rec.movie.vote_average !== 'number') {
             return false;
           }
           return rec.movie.vote_average >= minRating && 
-            rec.movie.vote_average <= recommendationFilters.maxRating &&
-            rec.movie.vote_count >= minVoteCount;
+            rec.movie.vote_average <= recommendationFilters.maxRating;
         });
 
         filtered = filtered.filter(rec => {
@@ -1044,8 +1025,7 @@ export const useMovieData = (settings?: AppSettings) => {
             { ...recommendationFilters, showKidsContent: settings?.showKidsContent ?? false, showAnimationContent: settings?.showAnimationContent ?? true, showAnimeContent: settings?.showAnimeContent ?? true },
             settings ? {
               recommendationCount: settings.recommendationCount,
-              minTmdbScore: settings.minTmdbScore,
-              minTmdbVoteCount: settings.minTmdbVoteCount
+              minTmdbScore: settings.minTmdbScore
             } : {},
             watchlistIds
           );
@@ -1215,8 +1195,7 @@ export const useMovieData = (settings?: AppSettings) => {
         recommendationFilters, // Filtreleri geçir
         settings ? {
           recommendationCount: settings.recommendationCount,
-          minTmdbScore: settings.minTmdbScore,
-          minTmdbVoteCount: settings.minTmdbVoteCount
+          minTmdbScore: settings.minTmdbScore
         } : {} // Ayarları geçir
       );
       

--- a/src/features/recommendation/services/recommendationService.ts
+++ b/src/features/recommendation/services/recommendationService.ts
@@ -28,7 +28,6 @@ export class RecommendationService {
     settings?: {
       recommendationCount?: number;
       minTmdbScore?: number;
-      minTmdbVoteCount?: number;
     },
     watchlistIds?: number[]
   ): Promise<Recommendation[]> {
@@ -186,12 +185,10 @@ export class RecommendationService {
 
       // Rating filter
       const minRating = Math.max(filters.minRating, settings?.minTmdbScore ?? 0);
-      const minVoteCount = settings?.minTmdbVoteCount ?? 0;
       filteredRecommendations = filteredRecommendations.filter(rec => {
-        if (!rec?.movie || typeof rec.movie.vote_average !== 'number' || typeof rec.movie.vote_count !== 'number') return false;
+        if (!rec?.movie || typeof rec.movie.vote_average !== 'number') return false;
         return rec.movie.vote_average >= minRating && 
-               rec.movie.vote_average <= filters.maxRating &&
-               rec.movie.vote_count >= minVoteCount;
+               rec.movie.vote_average <= filters.maxRating;
       });
 
       // Language filter


### PR DESCRIPTION
### Motivation
- The UI copy "TMDB'de minimum kaç kişi puanlamış olması gerekir" and its behavior should be removed so recommendations/search are not filtered by TMDb vote count.

### Description
- Removed `minTmdbVoteCount` from the `AppSettings` type and default settings used in `SettingsModal`, `useSettings` and onboarding defaults.
- Deleted the vote-count slider and explanatory text from the settings modal UI (`SettingsModal.tsx`).
- Removed all vote-count based filters from search flows and fallback search in `useMovieData.ts` so results no longer filter by `vote_count`.
- Stopped passing `minTmdbVoteCount` into recommendation generation and removed vote-count checks from recommendation filtering logic in `recommendationService.ts`.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite started successfully and the app was reachable at the local address. (succeeded)
- Ran a Playwright script to open the app and capture a screenshot of the settings modal to verify the slider/UI removal (screenshot artifact produced). (succeeded)
- No unit/integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843238fa1883268ef6f473d8646504)