### PR TITLE
Embed trailers in-place and show fallback modal when missing

### DIFF
--- a/src/features/content/components/MovieCard.tsx
+++ b/src/features/content/components/MovieCard.tsx
@@ -33,7 +33,10 @@ export const MovieCard: React.FC<MovieCardProps> = React.memo(({
   hideInfoBadges = false
 }) => {
   const [showDetails, setShowDetails] = useState(false);
+  const [showTrailer, setShowTrailer] = useState(false);
   const [movieDetails, setMovieDetails] = useState<any>(null);
+  const [trailerKey, setTrailerKey] = useState<string | null>(null);
+  const [trailerError, setTrailerError] = useState<string | null>(null);
   const [loadingTrailer, setLoadingTrailer] = useState(false);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -73,6 +76,7 @@ export const MovieCard: React.FC<MovieCardProps> = React.memo(({
 
   const handleTrailerClick = useCallback(async () => {
     setLoadingTrailer(true);
+    setTrailerError(null);
     try {
       if (!movieDetails) {
         const details = isTV 
@@ -83,22 +87,30 @@ export const MovieCard: React.FC<MovieCardProps> = React.memo(({
         if (details?.videos?.results) {
           const trailerKey = getTrailerKey(details);
           if (trailerKey) {
-            openYouTubeInNewTab(trailerKey);
+            setTrailerKey(trailerKey);
+            setShowTrailer(true);
           } else {
-            window.open(`https://www.themoviedb.org/${isTV ? 'tv' : 'movie'}/${movie.id}`, '_blank', 'noopener,noreferrer');
+            setTrailerKey(null);
+            setTrailerError('Fragman bulunamadı.');
+            setShowTrailer(true);
           }
         }
       } else {
         const trailerKey = getTrailerKey(movieDetails);
         if (trailerKey) {
-          openYouTubeInNewTab(trailerKey);
+          setTrailerKey(trailerKey);
+          setShowTrailer(true);
         } else {
-          window.open(`https://www.themoviedb.org/${isTV ? 'tv' : 'movie'}/${movie.id}`, '_blank', 'noopener,noreferrer');
+          setTrailerKey(null);
+          setTrailerError('Fragman bulunamadı.');
+          setShowTrailer(true);
         }
       }
     } catch (error) {
       console.error('Error loading trailer:', error);
-      window.open(`https://www.themoviedb.org/${isTV ? 'tv' : 'movie'}/${movie.id}`, '_blank', 'noopener,noreferrer');
+      setTrailerKey(null);
+      setTrailerError('Fragman yüklenirken bir sorun oluştu.');
+      setShowTrailer(true);
     } finally {
       setLoadingTrailer(false);
     }
@@ -159,11 +171,6 @@ export const MovieCard: React.FC<MovieCardProps> = React.memo(({
     }
     return (movie as any).release_date;
   }, [isTV, movie]);
-
-  const openYouTubeInNewTab = useCallback((key: string) => {
-    const youtubeUrl = `https://www.youtube.com/watch?v=${key}`;
-    window.open(youtubeUrl, '_blank', 'noopener,noreferrer');
-  }, []);
 
   // Extract topics from overview and keywords
   const getTopics = useCallback((): string[] => {
@@ -681,6 +688,48 @@ export const MovieCard: React.FC<MovieCardProps> = React.memo(({
                       </div>
                     </div>
                   )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showTrailer && (
+        <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-2xl max-w-4xl w-full border border-slate-700/50 shadow-2xl">
+            <div className="flex items-center justify-between p-6 border-b border-slate-700/50">
+              <h3 className="text-xl font-bold text-theme-primary">{title} Fragmanı</h3>
+              <button
+                onClick={() => {
+                  setShowTrailer(false);
+                  setTrailerKey(null);
+                  setTrailerError(null);
+                }}
+                className="text-slate-400 hover:text-theme-primary text-2xl transition-colors"
+                aria-label="Fragmanı kapat"
+              >
+                ×
+              </button>
+            </div>
+            <div className="p-6">
+              {trailerKey ? (
+                <div className="relative w-full overflow-hidden rounded-xl border border-slate-700/50 bg-black">
+                  <div className="pb-[56.25%]" />
+                  <iframe
+                    title={`${title} fragmanı`}
+                    src={tmdbService.getYouTubeUrl(trailerKey)}
+                    className="absolute inset-0 h-full w-full"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
+              ) : (
+                <div className="rounded-xl border border-slate-700/50 bg-slate-900/60 p-6 text-center text-slate-300">
+                  <p className="text-base font-medium">{trailerError ?? 'Fragman bulunamadı.'}</p>
+                  <p className="mt-2 text-sm text-slate-400">
+                    Bu içerik için gömülü fragman şu anda mevcut değil.
+                  </p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
### Motivation
- Allow users to watch trailers in-place instead of opening YouTube in a new tab so the experience remains in-app and matches user expectation when they click the "Fragman" button.
- Provide clear inline feedback when no YouTube trailer exists or when loading the trailer fails.

### Description
- Replaced the previous external-open behavior by removing `openYouTubeInNewTab` and instead added `showTrailer`, `trailerKey`, and `trailerError` states to `MovieCard` and `RecommendationCard` to drive an inline modal player.
- When a trailer `key` is found the modal renders an `<iframe>` using `tmdbService.getYouTubeUrl(trailerKey)`; when not found or on error the modal shows a friendly message (`'Fragman bulunamadı.'` or `'Fragman yüklenirken bir sorun oluştu.'`).
- Mirror changes across `src/features/content/components/MovieCard.tsx` and `src/features/recommendation/components/RecommendationCard.tsx` so both card types behave consistently.
- Preserve details-loading behavior by fetching `movieDetails` before extracting the trailer key via existing `getTrailerKey` logic.

### Testing
- Ran the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which started Vite successfully but produced a non-fatal `Error: spawn xdg-open ENOENT` warning (succeeded with warning). 
- Executed a Playwright script that navigated to the local app, clicked the first `Fragman` button, and produced the screenshot `artifacts/trailer-embed.png` to verify the modal and iframe rendering (script completed successfully and artifact produced).
- No unit tests (`vitest`) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698432ebf47083269723f2d3ca8d0527)