### PR TITLE
Fix recommendation filter consistency for kids content and match-score handling

### DIFF
--- a/src/features/recommendation/components/RecommendationFilters.tsx
+++ b/src/features/recommendation/components/RecommendationFilters.tsx
@@ -13,6 +13,9 @@ interface RecommendationFiltersProps {
     sortBy: 'match_score' | 'rating' | 'year' | 'title';
     minMatchScore: number;
     languages?: string[]; // Yeni eklenen dil filtresi
+    showKidsContent?: boolean;
+    showAnimationContent?: boolean;
+    showAnimeContent?: boolean;
   };
   genres: Genre[];
   onFiltersChange: (filters: any) => void;
@@ -127,9 +130,12 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
       mediaType: 'all',
       sortBy: 'match_score',
       minMatchScore: 0,
-      languages: []
+      languages: [],
+      showKidsContent: filters.showKidsContent,
+      showAnimationContent: filters.showAnimationContent,
+      showAnimeContent: filters.showAnimeContent
     });
-  }, [onFiltersChange]);
+  }, [filters.showAnimeContent, filters.showAnimationContent, filters.showKidsContent, onFiltersChange]);
 
   const activeFiltersCount = useMemo(() => 
     filters.genres.length + 

--- a/src/features/recommendation/services/recommendationService.ts
+++ b/src/features/recommendation/services/recommendationService.ts
@@ -127,14 +127,17 @@ export class RecommendationService {
 
     // Final filtreleme ve sıralama
     let filteredRecommendations = recommendations
-      .filter(rec => !ratedContentIds.has(rec.movie.id) && !watchlistContentIds.has(rec.movie.id))
-      // Çocuk içeriklerini her zaman filtrele
-      .filter(rec => {
+      .filter(rec => !ratedContentIds.has(rec.movie.id) && !watchlistContentIds.has(rec.movie.id));
+
+    const allowKidsContent = filters?.showKidsContent ?? settings?.showKidsContent ?? false;
+    if (!allowKidsContent) {
+      filteredRecommendations = filteredRecommendations.filter(rec => {
         if (!rec?.movie?.genre_ids) return true;
         // 16: Animasyon, 10751: Aile
         const isKidsGenre = rec.movie.genre_ids.includes(16) || rec.movie.genre_ids.includes(10751);
         return !isKidsGenre;
       });
+    }
 
     // Filtreleri uygula
     if (filters) {

--- a/src/features/recommendation/services/tmdbRecommendationService.ts
+++ b/src/features/recommendation/services/tmdbRecommendationService.ts
@@ -315,7 +315,7 @@ export class TMDbRecommendationService {
       );
 
       // Minimum match score filtresi
-      const minMatchScore = filters?.minMatchScore || 60;
+      const minMatchScore = filters?.minMatchScore ?? 60;
       if (matchScore < minMatchScore) {
         continue;
       }


### PR DESCRIPTION
### Motivation
- Users reported items (e.g. a card with %80 match) disappearing when certain AI filters are applied; root cause was inconsistent handling of the `showKidsContent` / animation filters and an unintended `minMatchScore` defaulting behavior. 
- The goal is to make `showKidsContent` and animation-related flags respected consistently in search, curated discovery and recommendation generation paths and to ensure explicit `minMatchScore` values (including `0`) are honored.

### Description
- Applied `showKidsContent` checks to search results in `useMovieData` so search/fallback flows respect the user's kids-content setting and exclude genre ids `16`/`10751` when required. (`src/features/recommendation/hooks/useMovieData.ts`)
- Plumbed `showKidsContent` into curated content APIs and honored it when fetching initial or filtered curated content; added an `allowKidsContent` helper and passed it to internal helpers to avoid repeated logic. (`src/features/recommendation/services/curatedMovieService.ts`)
- Made final recommendation generation respect `showKidsContent` (falling back to `settings` when filters are absent) instead of always removing kids content. (`src/features/recommendation/services/recommendationService.ts`)
- Preserved kids/animation filter flags when clearing UI filters and expanded the `RecommendationFilters` type to include `showKidsContent`, `showAnimationContent`, and `showAnimeContent`. (`src/features/recommendation/components/RecommendationFilters.tsx`)
- Ensured TMDb-based recommendation processing honors explicit `minMatchScore` values (including `0`) by switching to the nullish coalescing operator (`??`). (`src/features/recommendation/services/tmdbRecommendationService.ts`)

### Testing
- No automated test suite was executed as part of this change; only code changes were committed and staged (`git commit` succeeded).
- Manual code-level checks were performed across the modified files to ensure the `showKidsContent` flag is passed and used consistently and that `minMatchScore` uses `??` so `0` is treated as a valid value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698434b539548326bb584f3d71df35a9)