### PR TITLE
Respect kids-content across recommendation flows and add fallback genre list

### DIFF
--- a/src/features/recommendation/components/RecommendationFilters.tsx
+++ b/src/features/recommendation/components/RecommendationFilters.tsx
@@ -13,6 +13,9 @@ interface RecommendationFiltersProps {
     sortBy: 'match_score' | 'rating' | 'year' | 'title';
     minMatchScore: number;
     languages?: string[]; // Yeni eklenen dil filtresi
+    showKidsContent?: boolean;
+    showAnimationContent?: boolean;
+    showAnimeContent?: boolean;
   };
   genres: Genre[];
   onFiltersChange: (filters: any) => void;
@@ -95,6 +98,36 @@ const LANGUAGE_OPTIONS = [
   { code: 'nd', name: 'Kuzey Ndebele', flag: '🇿🇦' }
 ];
 
+const FALLBACK_GENRES: Genre[] = [
+  { id: 28, name: 'Aksiyon' },
+  { id: 12, name: 'Macera' },
+  { id: 16, name: 'Animasyon' },
+  { id: 35, name: 'Komedi' },
+  { id: 80, name: 'Suç' },
+  { id: 99, name: 'Belgesel' },
+  { id: 18, name: 'Dram' },
+  { id: 10751, name: 'Aile' },
+  { id: 14, name: 'Fantastik' },
+  { id: 36, name: 'Tarih' },
+  { id: 27, name: 'Korku' },
+  { id: 10402, name: 'Müzik' },
+  { id: 9648, name: 'Gizem' },
+  { id: 10749, name: 'Romantik' },
+  { id: 878, name: 'Bilim Kurgu' },
+  { id: 10770, name: 'TV Filmi' },
+  { id: 53, name: 'Gerilim' },
+  { id: 10752, name: 'Savaş' },
+  { id: 37, name: 'Western' },
+  { id: 10759, name: 'Aksiyon & Macera' },
+  { id: 10765, name: 'Bilim Kurgu & Fantazi' },
+  { id: 10762, name: 'Çocuk' },
+  { id: 10763, name: 'Haber' },
+  { id: 10764, name: 'Gerçeklik' },
+  { id: 10766, name: 'Pembe Dizi' },
+  { id: 10767, name: 'Talk' },
+  { id: 10768, name: 'Savaş & Politik' }
+];
+
 export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React.memo(({
   filters,
   genres,
@@ -127,9 +160,12 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
       mediaType: 'all',
       sortBy: 'match_score',
       minMatchScore: 0,
-      languages: []
+      languages: [],
+      showKidsContent: filters.showKidsContent,
+      showAnimationContent: filters.showAnimationContent,
+      showAnimeContent: filters.showAnimeContent
     });
-  }, [onFiltersChange]);
+  }, [filters.showAnimeContent, filters.showAnimationContent, filters.showKidsContent, onFiltersChange]);
 
   const activeFiltersCount = useMemo(() => 
     filters.genres.length + 
@@ -139,14 +175,19 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
     (filters.minMatchScore !== 0 ? 1 : 0) +
     ((filters.languages || []).length > 0 ? 1 : 0), [filters]);
 
+  const usingFallbackGenres = !Array.isArray(genres) || genres.length === 0;
+  const effectiveGenres = useMemo(() => (
+    usingFallbackGenres ? FALLBACK_GENRES : genres
+  ), [genres, usingFallbackGenres]);
+
   const popularGenreIds = [28, 35, 18, 12, 878, 27, 10749, 53, 16, 80, 14, 10765];
-  const genreMap = useMemo(() => new Map(genres.map(genre => [genre.id, genre])), [genres]);
+  const genreMap = useMemo(() => new Map(effectiveGenres.map(genre => [genre.id, genre])), [effectiveGenres]);
   const popularGenres = useMemo(() => popularGenreIds
     .map(id => genreMap.get(id))
     .filter((genre): genre is Genre => Boolean(genre)), [genreMap]);
 
   // Popüler türleri önce göster
-  const sortedGenres = useMemo(() => [...genres].sort((a, b) => {
+  const sortedGenres = useMemo(() => [...effectiveGenres].sort((a, b) => {
     const aIndex = popularGenreIds.indexOf(a.id);
     const bIndex = popularGenreIds.indexOf(b.id);
     
@@ -154,7 +195,7 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
     if (aIndex !== -1) return -1;
     if (bIndex !== -1) return 1;
     return a.name.localeCompare(b.name, 'tr');
-  }), [genres, popularGenreIds]);
+  }), [effectiveGenres, popularGenreIds]);
 
   const [showOtherLanguages, setShowOtherLanguages] = React.useState(false);
 
@@ -429,6 +470,11 @@ export const RecommendationFilters: React.FC<RecommendationFiltersProps> = React
             <label className="block text-sm font-medium text-theme-primary mb-2">
               Türler (Yeni Önerilerde) ({filters.genres.length} seçili)
             </label>
+            {usingFallbackGenres && (
+              <p className="text-xs text-amber-400 mb-2">
+                Tür listesi yüklenemedi, varsayılan türler gösteriliyor.
+              </p>
+            )}
             
             {/* Popüler türler için hızlı seçim */}
             <div className="mb-3">

--- a/src/features/recommendation/services/recommendationService.ts
+++ b/src/features/recommendation/services/recommendationService.ts
@@ -127,14 +127,17 @@ export class RecommendationService {
 
     // Final filtreleme ve sıralama
     let filteredRecommendations = recommendations
-      .filter(rec => !ratedContentIds.has(rec.movie.id) && !watchlistContentIds.has(rec.movie.id))
-      // Çocuk içeriklerini her zaman filtrele
-      .filter(rec => {
+      .filter(rec => !ratedContentIds.has(rec.movie.id) && !watchlistContentIds.has(rec.movie.id));
+
+    const allowKidsContent = filters?.showKidsContent ?? settings?.showKidsContent ?? false;
+    if (!allowKidsContent) {
+      filteredRecommendations = filteredRecommendations.filter(rec => {
         if (!rec?.movie?.genre_ids) return true;
         // 16: Animasyon, 10751: Aile
         const isKidsGenre = rec.movie.genre_ids.includes(16) || rec.movie.genre_ids.includes(10751);
         return !isKidsGenre;
       });
+    }
 
     // Filtreleri uygula
     if (filters) {

--- a/src/features/recommendation/services/tmdbRecommendationService.ts
+++ b/src/features/recommendation/services/tmdbRecommendationService.ts
@@ -315,7 +315,7 @@ export class TMDbRecommendationService {
       );
 
       // Minimum match score filtresi
-      const minMatchScore = filters?.minMatchScore || 60;
+      const minMatchScore = filters?.minMatchScore ?? 60;
       if (matchScore < minMatchScore) {
         continue;
       }


### PR DESCRIPTION
### Motivation
- Prevent user-visible disappearance of items by making `showKidsContent` respected consistently across search, curated discovery and recommendation generation paths.
- Ensure explicit `minMatchScore` values (including `0`) are honored when processing TMDb recommendations.
- Avoid an empty/blank genre UI when the API fails to return genres by providing a local fallback list.

### Description
- Added a `FALLBACK_GENRES` list and logic in `src/features/recommendation/components/RecommendationFilters.tsx` to use and surface a warning when API genres are missing, and preserved `showKidsContent`/animation flags when clearing filters.
- Plumbed `showKidsContent` through curated content and recommendation flows by adding `showKidsContent` to `CuratedMovieService` APIs and using an `allowKidsContent` helper to filter out genre ids `16`/`10751` where appropriate (`src/features/recommendation/services/curatedMovieService.ts`).
- Applied `showKidsContent` filtering to search/fallback flows and final recommendation filtering in `src/features/recommendation/hooks/useMovieData.ts` and in `src/features/recommendation/services/recommendationService.ts` so user/settings flags are consistently respected.
- Fixed TMDb recommendation processing to honor explicit `minMatchScore` values by switching to the nullish coalescing operator (`??`) in `src/features/recommendation/services/tmdbRecommendationService.ts`.

### Testing
- No automated test suite was executed for this change.
- A local dev server was started as a smoke check and Vite reported `ready`, but the Playwright screenshot attempt timed out and did not complete.
- The code changes were committed successfully (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698434b539548326bb584f3d71df35a9)