### PR TITLE
Enable evaluation flow for untrained neural model UI

### DIFF
--- a/src/features/learning/components/NeuralModelInfo.test.tsx
+++ b/src/features/learning/components/NeuralModelInfo.test.tsx
@@ -217,7 +217,6 @@ describe('NeuralModelInfo', () => {
     test('should show evaluation button when model is available', async () => {
       // Mock model info to show model is available
       const mockInitializeModel = vi.fn().mockResolvedValue({
-        isAvailable: true,
         accuracy: 0.85,
         lastTrained: Date.now(),
         trainingData: 25
@@ -241,6 +240,11 @@ describe('NeuralModelInfo', () => {
     });
 
     test('should call evaluateModel when evaluation button is clicked', async () => {
+      const mockInitializeModel = vi.fn().mockResolvedValue({
+        accuracy: 0.85,
+        lastTrained: Date.now(),
+        trainingData: 25
+      });
       const mockEvaluateModel = vi.fn().mockResolvedValue({
         accuracy: 0.85,
         mae: 0.5,
@@ -248,6 +252,7 @@ describe('NeuralModelInfo', () => {
         coverage: 0.9
       });
 
+      (NeuralRecommendationService.initializeModel as any) = mockInitializeModel;
       (NeuralRecommendationService.evaluateModel as any) = mockEvaluateModel;
 
       const sufficientRatings = Array.from({ length: 25 }, (_, i) => ({


### PR DESCRIPTION
### Motivation
- Allow users to run model evaluation when there is enough rated data even if a persisted model is not yet trained.  
- Improve UX by auto-training on-demand when evaluation is requested for an untrained model and by surfacing a clear action label.  
- Prevent concurrent training/evaluation and clarify button/debug messaging to avoid a non-interactive state.

### Description
- Added `isEvaluating` state and updated `handleEvaluateModel` to require at least 10 rated items, auto-train when the model is unavailable and there are >=20 ratings, and to manage `isTraining`/`isEvaluating` flags.  
- Changed evaluation button visibility/labeling and disabled styling to `Eğit ve değerlendir` when the model is not available and to disable while actions run.  
- Updated debug messaging shown next to the button to indicate when evaluation will trigger training, and centralized training-data checks into `trainingDataCount`, `canTrain`, and `canEvaluate`.  
- Adjusted tests in `NeuralModelInfo.test.tsx` to mock `NeuralRecommendationService.initializeModel` for the evaluation scenarios so evaluation button visibility and click behavior are deterministic.

### Testing
- Started the dev server with `npm run dev` (Vite reported ready and served the app), which succeeded.  
- Attempted an automated UI snapshot with Playwright but the headless Chromium instance crashed (SIGSEGV), so the screenshot run failed.  
- Updated unit tests in `src/features/learning/components/NeuralModelInfo.test.tsx` were not executed as part of this change (no `vitest` run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984673360288326b640fbe7bcf8cd11)